### PR TITLE
Change defaulting of TARGETARCH

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,6 +1,6 @@
 FROM ubuntu:20.04
 
-ARG TARGETARCH=amd64
+ARG TARGETARCH
 
 RUN mkdir -p /usr/share/man/man1 \
     && apt-get update \
@@ -12,7 +12,7 @@ RUN mkdir -p /usr/share/man/man1 \
     && curl -sL https://deb.nodesource.com/setup_14.x | bash - \
     && apt-get update \
     && apt-get install -y bash binutils php8.0-cli php8.0-zip php8.0-mbstring php8.0-xml nodejs adoptopenjdk-8-hotspot-jre xfonts-75dpi xfonts-base fontconfig libjpeg-turbo8 \
-    && curl -L -o /wkhtmltox.deb https://github.com/wkhtmltopdf/packaging/releases/download/0.12.6-1/wkhtmltox_0.12.6-1.focal_$TARGETARCH.deb \
+    && curl -L -o /wkhtmltox.deb https://github.com/wkhtmltopdf/packaging/releases/download/0.12.6-1/wkhtmltox_0.12.6-1.focal_${TARGETARCH:-amd64}.deb \
     && dpkg -i /wkhtmltox.deb \
     && npm install -g redoc-cli marked \
     && apt-get clean \


### PR DESCRIPTION
This doesn't actually work - it prevents the TARGETARCH being populated. I suspect buildkit implements it as a default, then this overrides the default