### PR TITLE
Use ghcr.io in image name to use the right registry

### DIFF
--- a/.github/workflows/publish-docker-image-to-github-registry.yml
+++ b/.github/workflows/publish-docker-image-to-github-registry.yml
@@ -17,7 +17,7 @@ jobs:
         uses: docker/metadata-action@v3
         with:
           images: |
-            roave/docbooktool
+            ghcr.io/roave/docbooktool
           tags: |
             type=semver,pattern={{version}}
 


### PR DESCRIPTION
Use ghcr.io in image name, was pushing to wrong registry.