### PR TITLE
Point to GHCR repo

### DIFF
--- a/.github/workflows/publish-docker-image-to-github-registry.yml
+++ b/.github/workflows/publish-docker-image-to-github-registry.yml
@@ -17,7 +17,7 @@ jobs:
         uses: docker/metadata-action@v3
         with:
           images: |
-            roave/docbooktool
+            ghcr.io/roave/docbooktool
           tags: |
             type=semver,pattern={{version}}
 


### PR DESCRIPTION
The same change worked on my fork and pushed a multi-arch image https://github.com/ciaranmcnulty/DocbookTool/pkgs/container/docbooktool

