### PR TITLE
Use fully qualified tags for good hygiene

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -21,14 +21,14 @@ jobs:
           docker buildx build \
             --load \
             --target=development \
-            --tag=test-image \
+            --tag=ghcr.io/roave/docbooktool:test-image \
             .
 
       - name: "Psalm"
-        run: "docker run --rm --entrypoint=php test-image vendor/bin/psalm"
+        run: "docker run --rm --entrypoint=php ghcr.io/roave/docbooktool:test-image vendor/bin/psalm"
 
       - name: "PHPUnit"
-        run: "docker run --rm --entrypoint=php test-image vendor/bin/phpunit"
+        run: "docker run --rm --entrypoint=php ghcr.io/roave/docbooktool:test-image vendor/bin/phpunit"
 
       - name: "PHPCS"
-        run: "docker run --rm --entrypoint=php test-image vendor/bin/phpcs"
+        run: "docker run --rm --entrypoint=php ghcr.io/roave/docbooktool:test-image vendor/bin/phpcs"

--- a/Makefile
+++ b/Makefile
@@ -7,13 +7,13 @@ help:
 	@grep -E '^[a-zA-Z_-]+:.*?## .*$$' $(MAKEFILE_LIST) | sort | awk 'BEGIN {FS = ":.*?## "}; {printf "\033[36m%-30s\033[0m %s\n", $$1, $$2}'
 
 build: ## Builds the development image needed to run tests etc.
-	docker buildx build --load --target=development --tag=test-image .
+	docker buildx build --load --target=development --tag=ghcr.io/roave/docbooktool:test-image .
 
 test: build ## Run the unit and integration tests
-	docker run --rm --entrypoint=php test-image vendor/bin/phpunit
+	docker run --rm --entrypoint=php ghcr.io/roave/docbooktool:test-image vendor/bin/phpunit
 
 cs: build ## Run coding standards checks
-	docker run --rm --entrypoint=php test-image vendor/bin/phpcs
+	docker run --rm --entrypoint=php ghcr.io/roave/docbooktool:test-image vendor/bin/phpcs
 
 static-analysis: build ## Run the static analysis checks
-	docker run --rm --entrypoint=php test-image vendor/bin/psalm
+	docker run --rm --entrypoint=php ghcr.io/roave/docbooktool:test-image vendor/bin/psalm


### PR DESCRIPTION
Tagging as `test-image` actually means `docker.io/test-image:latest` which isn't scoped properly. Even though we're not pushing anywhere it's good practice to not be too 'global'