### PR TITLE
Dockerfile bikeshedding

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -11,7 +11,8 @@ RUN \
     --mount=source=package-lock.json,target=package-lock.json,rw=true \
     npm ci
 
-FROM composer-base-image AS production-dependencies
+
+FROM composer-base-image AS production-composer-dependencies
 
 WORKDIR /build
 
@@ -26,7 +27,8 @@ RUN  \
     --no-plugins \
     --no-scripts
 
-FROM production-dependencies AS development-dependencies
+
+FROM production-dependencies AS development-composer-dependencies
 
 RUN \
     --mount=type=cache,target=/tmp,id=composer \
@@ -37,6 +39,7 @@ RUN \
     --no-autoloader \
     --no-plugins \
     --no-scripts
+
 
 FROM ubuntu:20.04 AS base-dependencies
 
@@ -90,6 +93,7 @@ ENV DOCBOOK_TOOL_CONTENT_PATH=/docs-src/book \
 ENTRYPOINT ["bin/docbook-tool"]
 CMD ["--html", "--pdf"]
 
+
 FROM base-dependencies AS production
 
 RUN \
@@ -100,6 +104,7 @@ RUN \
     composer install \
     --classmap-authoritative \
     --no-dev
+
 
 FROM base-dependencies AS development
 
@@ -115,7 +120,7 @@ COPY ./composer.json \
     ./package-lock.json \
     ./
 
-COPY --from=production-dependencies /usr/bin/composer /usr/local/bin/composer
+COPY --from=composer-base-image /usr/bin/composer /usr/local/bin/composer
 
 RUN \
     --mount=type=cache,target=/root/.composer,id=composer \

--- a/Dockerfile
+++ b/Dockerfile
@@ -64,7 +64,7 @@ RUN  \
     --no-plugins
 
 
-FROM base-with-dependencies AS development-composer-dependencies
+FROM production-composer-dependencies AS development-composer-dependencies
 
 WORKDIR /build
 

--- a/Dockerfile
+++ b/Dockerfile
@@ -34,6 +34,7 @@ RUN export DEBIAN_FRONTEND="noninteractive" \
       php8.1-zip \
       php8.1-mbstring \
       php8.1-xml \
+      php8.1-curl \
       nodejs \
       adoptopenjdk-8-hotspot-jre \
       xfonts-75dpi \
@@ -96,19 +97,6 @@ ENV DOCBOOK_TOOL_CONTENT_PATH=/docs-src/book \
 
 ENTRYPOINT ["bin/docbook-tool"]
 CMD ["--html", "--pdf"]
-
-
-FROM base-with-codebase AS production
-
-COPY --from=production-composer-dependencies /build/vendor vendor
-RUN \
-    --mount=source=/usr/bin/composer,target=/usr/bin/composer,from=composer-base-image \
-    --mount=type=cache,target=/root/.composer,id=composer \
-    --mount=source=composer.json,target=composer.json \
-    --mount=source=composer.json,target=composer.lock,rw=true \
-    COMPOSER_DISABLE_NETWORK=1 composer dump-autoload \
-    --classmap-authoritative \
-    --no-dev
 
 
 FROM base-with-codebase AS development

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,18 +1,20 @@
 FROM composer:2.2.9 AS composer-base-image
+
 FROM node:17.7 AS npm-dependencies
+
+WORKDIR /app
 
 COPY ./package.json \
     ./package-lock.json \
-    /app/
+    ./
 
-RUN cd /app \
-    && npm ci
+RUN npm ci
 
 FROM composer-base-image AS production-dependencies
 
 COPY ./composer.json \
     ./composer.lock \
-    /app/
+    ./
 
 RUN composer install \
     --ignore-platform-reqs \
@@ -62,22 +64,24 @@ RUN export DEBIAN_FRONTEND="noninteractive" \
     && rm -rf /var/lib/apt/lists/* \
     && mkdir -p /docs-package/pdf /app /docs-src/book /docs-src/templates /docs-src/features
 
+WORKDIR /app
+
 COPY ./composer.json \
     ./composer.lock \
     ./package.json \
     ./package-lock.json \
-    /app/
+    ./
 
-COPY ./src /app/src
-COPY ./bin /app/bin
+COPY ./src ./src
+COPY ./bin ./bin
 
-ADD https://github.com/plantuml/plantuml/releases/download/v1.2022.2/plantuml-1.2022.2.jar /app/bin/plantuml.jar
+ADD https://github.com/plantuml/plantuml/releases/download/v1.2022.2/plantuml-1.2022.2.jar bin/plantuml.jar
 
 COPY --from=production-dependencies /usr/bin/composer /usr/local/bin/composer
-COPY --from=npm-dependencies /app/node_modules /app/node_modules
+COPY --from=npm-dependencies /app/node_modules node_modules
 
-RUN ln -s /app/node_modules/.bin/marked /usr/local/bin/marked \
-    && ln -s /app/node_modules/.bin/redoc-cli /usr/local/bin/redoc-cli
+RUN ln -s node_modules/.bin/marked /usr/local/bin/marked \
+    && ln -s node_modules/.bin/redoc-cli /usr/local/bin/redoc-cli
 
 ENV DOCBOOK_TOOL_CONTENT_PATH=/docs-src/book \
     DOCBOOK_TOOL_TEMPLATE_PATH=/docs-src/templates \
@@ -85,14 +89,12 @@ ENV DOCBOOK_TOOL_CONTENT_PATH=/docs-src/book \
     DOCBOOK_TOOL_OUTPUT_HTML_FILE=/docs-package/index.html \
     DOCBOOK_TOOL_OUTPUT_PDF_PATH=/docs-package/pdf
 
-WORKDIR /app
-
 ENTRYPOINT ["bin/docbook-tool"]
 CMD ["--html", "--pdf"]
 
 FROM base-dependencies AS production
 
-COPY --from=production-dependencies /app/vendor /app/vendor
+COPY --from=production-dependencies /app/vendor vendor
 
 RUN composer install \
     --classmap-authoritative \
@@ -101,12 +103,12 @@ RUN composer install \
 
 FROM base-dependencies AS development
 
-COPY --from=development-dependencies /app/vendor /app/vendor
+COPY --from=development-dependencies /app/vendor vendor
 COPY ./phpcs.xml.dist \
     ./phpunit.xml.dist \
     ./psalm.xml.dist \
-    /app/
-COPY ./test /app/test
+    ./
+COPY ./test test
 
 RUN composer install \
     --classmap-authoritative \

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,6 +1,7 @@
 FROM composer:2.2.9 AS composer-base-image
+FROM node:17.7 AS npm-base-image
 
-FROM node:17.7 AS npm-dependencies
+FROM npm-base-image AS npm-dependencies
 
 WORKDIR /app
 

--- a/Dockerfile
+++ b/Dockerfile
@@ -80,10 +80,10 @@ FROM base-with-dependencies AS base-with-codebase
 
 WORKDIR /app
 
-COPY ./src ./src
-COPY ./bin ./bin
+COPY --link ./src ./src
+COPY --link ./bin ./bin
 
-COPY --from=npm-dependencies /build/node_modules node_modules
+COPY --link --from=npm-dependencies /build/node_modules node_modules
 
 RUN ln -s node_modules/.bin/marked /usr/local/bin/marked \
     && ln -s node_modules/.bin/redoc-cli /usr/local/bin/redoc-cli
@@ -113,20 +113,20 @@ RUN \
 
 FROM base-with-codebase AS development
 
-COPY ./phpcs.xml.dist \
+COPY --link ./phpcs.xml.dist \
     ./phpunit.xml.dist \
     ./psalm.xml.dist \
     ./
-COPY ./test test
+COPY --link ./test test
 
-COPY ./composer.json \
+COPY --link ./composer.json \
     ./composer.lock \
     ./package.json \
     ./package-lock.json \
     ./
 
-COPY --from=composer-base-image /usr/bin/composer /usr/local/bin/composer
-COPY --from=development-composer-dependencies /build/vendor vendor
+COPY --link --from=composer-base-image /usr/bin/composer /usr/local/bin/composer
+COPY --link --from=development-composer-dependencies /build/vendor vendor
 
 # run the plugins
 RUN \
@@ -144,7 +144,7 @@ RUN touch .tested
 
 FROM base-with-codebase AS production
 
-COPY --from=production-composer-dependencies /build/vendor vendor
+COPY --link --from=production-composer-dependencies /build/vendor vendor
 
 RUN \
     --mount=source=/usr/bin/composer,target=/usr/bin/composer,from=composer-base-image \
@@ -156,4 +156,4 @@ RUN \
     --no-dev
 
 # The tests must have run to build production
-COPY --from=tested /app/.tested .
+COPY --link --from=tested /app/.tested .

--- a/Makefile
+++ b/Makefile
@@ -9,6 +9,9 @@ help:
 build: ## Builds the development image needed to run tests etc.
 	docker buildx build --load --target=development --tag=ghcr.io/roave/docbooktool:test-image .
 
+build-tested: ## Builds the image and runs the tests but does not tag it
+	docker buildx build --target=tested --progress=plain .
+
 test: build ## Run the unit and integration tests
 	docker run --rm --entrypoint=php ghcr.io/roave/docbooktool:test-image vendor/bin/phpunit
 
@@ -17,3 +20,6 @@ cs: build ## Run coding standards checks
 
 static-analysis: build ## Run the static analysis checks
 	docker run --rm --entrypoint=php ghcr.io/roave/docbooktool:test-image vendor/bin/psalm
+
+production: ## Build and tag a production image
+	docker buildx build --load --target=production  --tag=ghcr.io/roave/docbooktool:latest .


### PR DESCRIPTION
A few improvements, it probably makes sense to step through the commits to get a sense of each change

This:
  * Reformats and renames some things
  * Reorders some elements to improve layer caching
  * Uses mounts for composer+npm to avoid having those tools in final images
  * Improves caching when docker cache is invalidated by using (shared) cache mounts
  * Runs the tests as part of docker build (but retains the make targets for local)