### PR TITLE
Reduce image size by not installing apt recommended packages

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -37,13 +37,13 @@ RUN export DEBIAN_FRONTEND="noninteractive" \
     && mkdir -p /usr/share/man/man1 \
     && apt-get update \
     && apt-get -y upgrade \
-    && apt-get install -y software-properties-common gnupg curl \
+    && apt-get install -y --no-install-recommends software-properties-common gnupg curl \
     && add-apt-repository --yes ppa:ondrej/php \
     && curl --silent https://adoptopenjdk.jfrog.io/adoptopenjdk/api/gpg/key/public | apt-key add - \
     && add-apt-repository --yes https://adoptopenjdk.jfrog.io/adoptopenjdk/deb/ \
     && curl -sL https://deb.nodesource.com/setup_14.x | bash - \
     && apt-get update \
-    && apt-get install -y \
+    && apt-get install -y --no-install-recommends \
       bash \
       binutils \
       graphviz \


### PR DESCRIPTION
With 1.3.0 using apt to install wkhtmltopdf instead of a .deb the image size increased

```
ghcr.io/roave/docbooktool   1.3.0             b8ad7ce04652   2 days ago      1.4GB
ghcr.io/roave/docbooktool   1.2.0             0e74b895f381   3 days ago      743MB
```

This PR uses the `--no-install-recommended` flag (suggested by @Ocramius) to reduce the amount of extra stuff we pull in, resulting in a ~700MB image again

The layer of the main `apt install` is significantly reduced in size:

```
< RUN /bin/sh -c export DEBIAN_FRONTEND="nonin…   629MB     buildkit.dockerfile.v0
---
> RUN /bin/sh -c export DEBIAN_FRONTEND="nonin…   1.23GB    buildkit.dockerfile.v0
```
