### PR TITLE
Publish docker tags for major/minor

### DIFF
--- a/.github/workflows/publish-docker-image-to-github-registry.yml
+++ b/.github/workflows/publish-docker-image-to-github-registry.yml
@@ -20,6 +20,8 @@ jobs:
             ghcr.io/roave/docbooktool
           tags: |
             type=semver,pattern={{version}}
+            type=semver,pattern={{major}}.{{minor}}
+            type=semver,pattern={{major}}
           target: production
 
       - name: Set up QEMU


### PR DESCRIPTION
This will allow users to specify `roave/docbooktool:1` and `roave/docbooktool:1.3` as well as specific patches, therefore getting updates when they pull