### PR TITLE
Cache apt activity

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -13,16 +13,15 @@ jobs:
         with:
           install: true
 
-      - name: Checkout source code
-        uses: actions/checkout@v3
-
       - name: "Build docker image"
-        run: |
-          docker buildx build \
-            --load \
-            --target=development \
-            --tag=ghcr.io/roave/docbooktool:test-image \
-            .
+        uses: "docker/build-push-action@v2"
+        with:
+          target: "development"
+          tags: "ghcr.io/roave/docbooktool:test-image"
+          push: "false"
+          load: "true"
+          cache-from: "type=gha,scope=ci-cache"
+          cache-to: "type=gha,mode=max,scope=ci-cache"
 
       - name: "Psalm"
         run: "docker run --rm --entrypoint=php ghcr.io/roave/docbooktool:test-image vendor/bin/psalm"

--- a/.github/workflows/publish-docker-image-to-github-registry.yml
+++ b/.github/workflows/publish-docker-image-to-github-registry.yml
@@ -37,18 +37,14 @@ jobs:
           username: ${{ github.actor }}
           password: ${{ secrets.GITHUB_TOKEN }}
 
-      - name: Cache Docker layers
-        uses: actions/cache@v3
-        with:
-          path: /tmp/.buildx-cache
-          key: ${{ runner.os }}
-
       - name: Build and Push to GitHub Packages
         uses: docker/build-push-action@v2
         with:
           tags: ${{ steps.meta.outputs.tags }}
           labels: ${{ steps.meta.outputs.labels }}
           platforms: linux/amd64,linux/arm64
-          cache-from: type=local,src=/tmp/.buildx-cache
-          cache-to: type=local,dest=/tmp/.buildx-cache,mode=max
+          cache-from: |
+            type=gha,scope=ci-cache
+            type=gha,scope=release-cache
+          cache-to: type=gha,mode=max,scope=release-cache
           push: true

--- a/Dockerfile
+++ b/Dockerfile
@@ -18,7 +18,11 @@ RUN \
 
 FROM ubuntu-base-image AS base-with-dependencies
 
-RUN export DEBIAN_FRONTEND="noninteractive" \
+RUN  \
+    --mount=type=cache,target=/var/cache/apt,sharing=private \
+    --mount=type=cache,target=/var/lib/apt/lists/,sharing=private \
+    export DEBIAN_FRONTEND="noninteractive" \
+    && rm /etc/apt/apt.conf.d/docker-clean \
     && mkdir -p /usr/share/man/man1 \
     && apt-get update \
     && apt-get -y upgrade \
@@ -44,8 +48,6 @@ RUN export DEBIAN_FRONTEND="noninteractive" \
       fontconfig \
       libjpeg-turbo8 \
       wkhtmltopdf \
-    && apt-get clean \
-    && rm -rf /var/lib/apt/lists/* \
     && mkdir -p /docs-package/pdf /app /docs-src/book /docs-src/templates /docs-src/features
 
 ADD https://github.com/plantuml/plantuml/releases/download/v1.2022.2/plantuml-1.2022.2.jar app/bin/plantuml.jar


### PR DESCRIPTION
Rather than deleting apt's cached .deb and lists, we can mount them into a cache directory.

To do this we need to remove the auto-cleanup script in /etc/apt/apt.conf.d/docker-clean

This would mostly be useful if we start --cache-from and --cache-to more and benchmark things, but it makes a difference locally. for me

Draft because it needs benchmarking once we get better GHA caching