### PR TITLE
Cache CI build to GHA

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -13,16 +13,15 @@ jobs:
         with:
           install: true
 
-      - name: Checkout source code
-        uses: actions/checkout@v3
-
       - name: "Build docker image"
-        run: |
-          docker buildx build \
-            --load \
-            --target=development \
-            --tag=ghcr.io/roave/docbooktool:test-image \
-            .
+        uses: "docker/build-push-action@v2"
+        with:
+          target: "development"
+          tags: "ghcr.io/roave/docbooktool:test-image"
+          push: "false"
+          load: "true"
+          cache-from: "type=gha,scope=ci-cache"
+          cache-to: "type=gha,mode=max,scope=ci-cache"
 
       - name: "Psalm"
         run: "docker run --rm --entrypoint=php ghcr.io/roave/docbooktool:test-image vendor/bin/psalm"

--- a/.github/workflows/publish-docker-image-to-github-registry.yml
+++ b/.github/workflows/publish-docker-image-to-github-registry.yml
@@ -37,18 +37,14 @@ jobs:
           username: ${{ github.actor }}
           password: ${{ secrets.GITHUB_TOKEN }}
 
-      - name: Cache Docker layers
-        uses: actions/cache@v3
-        with:
-          path: /tmp/.buildx-cache
-          key: ${{ runner.os }}
-
       - name: Build and Push to GitHub Packages
         uses: docker/build-push-action@v2
         with:
           tags: ${{ steps.meta.outputs.tags }}
           labels: ${{ steps.meta.outputs.labels }}
           platforms: linux/amd64,linux/arm64
-          cache-from: type=local,src=/tmp/.buildx-cache
-          cache-to: type=local,dest=/tmp/.buildx-cache,mode=max
+          cache-from: |
+            type=gha,scope=ci-cache
+            type=gha,scope=release-cache
+          cache-to: type=gha,mode=max,scope=release-cache
           push: true


### PR DESCRIPTION
This caches the CI build directly into GHA cache without messing around writing it to files first

CI build will build AMD layers of the `development` target, and push them into `ci-cache` scope.

On release, the builder builds multi-arch `production` target, and can either re-use existing layers from `release-cache` scope, or if the Dockerfile has changed it can pull at least the AMD version of the shared new layers from the `ci-cache` scope. Layers built on release are only persisted back into `release-cache` scope.

Lets all ignore the fact this change got accidentally pushed already

(Checkout action is no longer needed if the docker build is the only thing we are running)