### PR TITLE
Fix symbolic links for node tools, since relative path breaks symlinks

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -86,8 +86,8 @@ COPY --link ./bin ./bin
 
 COPY --link --from=npm-dependencies /build/node_modules node_modules
 
-RUN ln -s node_modules/.bin/marked /usr/local/bin/marked \
-    && ln -s node_modules/.bin/redoc-cli /usr/local/bin/redoc-cli
+RUN ln -s /app/node_modules/.bin/marked /usr/local/bin/marked \
+    && ln -s /app/node_modules/.bin/redoc-cli /usr/local/bin/redoc-cli
 
 ENV DOCBOOK_TOOL_CONTENT_PATH=/docs-src/book \
     DOCBOOK_TOOL_TEMPLATE_PATH=/docs-src/templates \


### PR DESCRIPTION
Reverts part of e46ebe5677e88bed87d082878da86c6d5012c919 where the workdir was stripped from the symbolic link, which breaks the symlink because the path is relative to the target, not the link.