### PR TITLE
Fix rendering of plantuml that contains a file name in its header 

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -46,7 +46,7 @@ RUN export DEBIAN_FRONTEND="noninteractive" \
     && rm -rf /var/lib/apt/lists/* \
     && mkdir -p /docs-package/pdf /app /docs-src/book /docs-src/templates /docs-src/features
 
-ADD https://github.com/plantuml/plantuml/releases/download/v1.2022.2/plantuml-1.2022.2.jar app/bin/plantuml.jar
+ADD https://github.com/plantuml/plantuml/releases/download/v1.2022.4/plantuml-1.2022.4.jar app/bin/plantuml.jar
 
 
 FROM base-with-dependencies AS production-composer-dependencies

--- a/test/fixture/docbook/test.md
+++ b/test/fixture/docbook/test.md
@@ -31,7 +31,7 @@ Links [here](https://www.google.com). **Bold**, _italic_, ~~strikethrough~~, `in
 ## A diagram
 
 ```puml
-@startuml
+@startuml dummy_filename
 Bob->Alice : hello
 hexagon TestingHexagon
 @enduml


### PR DESCRIPTION
When something like `@startuml foo` appears, plantuml generates `foo.png` but then the later steps fail to find it as they're looking for a hash filename

This preprocesses the PUML to remove any text on that line.

Also bumped the plantuml version