### PR TITLE
Added support for inlining an external PUML diagram

### DIFF
--- a/phpunit.xml.dist
+++ b/phpunit.xml.dist
@@ -12,9 +12,10 @@
             <directory>./test/unit</directory>
         </testsuite>
     </testsuites>
-    <coverage>
+    <coverage />
+    <source>
         <include>
             <directory suffix=".php">./src</directory>
         </include>
-    </coverage>
+    </source>
 </phpunit>

--- a/src/Formatter/InlineExternalImages.php
+++ b/src/Formatter/InlineExternalImages.php
@@ -15,6 +15,10 @@ use function is_string;
 use function preg_replace_callback;
 use function Safe\file_get_contents;
 use function sprintf;
+use function str_starts_with;
+use function trim;
+
+use const PHP_EOL;
 
 final class InlineExternalImages implements PageFormatter
 {
@@ -44,6 +48,15 @@ final class InlineExternalImages implements PageFormatter
                     $mime = ((array) getimagesize($fullImagePath))['mime'] ?? null;
 
                     if (! is_string($mime)) {
+                        if (str_starts_with($imageContent, '@startuml')) {
+                            return sprintf(
+                                '```puml%s%s%s```',
+                                PHP_EOL,
+                                trim($imageContent),
+                                PHP_EOL,
+                            );
+                        }
+
                         throw new RuntimeException('Unable to determine mime type of ' . $fullImagePath);
                     }
 

--- a/test/fixture/docbook/external-diagram.puml
+++ b/test/fixture/docbook/external-diagram.puml
@@ -1,0 +1,3 @@
+@startuml dummy_filename
+Bob->Alice : hello
+@enduml

--- a/test/fixture/docbook/test.md
+++ b/test/fixture/docbook/test.md
@@ -58,3 +58,7 @@ Here are some images:
 ![A smiley face in GIF](./smile.gif)
 
 They are hand drawn, that's why they look rubbish.
+
+## Inline PUML file
+
+![An external PlantUML diagram](./external-diagram.puml)

--- a/test/fixture/expectations/out.html
+++ b/test/fixture/expectations/out.html
@@ -78,6 +78,10 @@
 
 <p>They are hand drawn, that's why they look rubbish.</p>
 
+<h2>Inline PUML file</h2>
+
+<p><img src="data:image/png;base64,iVBORw%s" alt="Diagram" /></p>
+
             <br />
         </section>
     </div>

--- a/test/unit/Formatter/InlineExternalImagesTest.php
+++ b/test/unit/Formatter/InlineExternalImagesTest.php
@@ -89,6 +89,33 @@ MD,
         self::assertSame($expectedOutput, $formattedPage->content());
     }
 
+    public function testExternalPumlIsInlined(): void
+    {
+        $contentPath = __DIR__ . '/../../fixture/docbook';
+        $markdown    = <<<'MD'
+Here is some markdown
+![an external diagram](external-diagram.puml)
+More markdown
+MD;
+
+        $page = DocbookPage::fromSlugAndContent($contentPath . '/faked.md', 'slug', $markdown);
+
+        $formattedPage = (new InlineExternalImages($contentPath, new NullLogger()))($page);
+
+        self::assertSame(
+            <<<'MD'
+Here is some markdown
+```puml
+@startuml dummy_filename
+Bob->Alice : hello
+@enduml
+```
+More markdown
+MD,
+            $formattedPage->content(),
+        );
+    }
+
     public function testImageNotExisting(): void
     {
         $this->expectException(FilesystemException::class);


### PR DESCRIPTION
A PlantUML diagram referenced externally like an image can now be inlined, and subsequently rendered by the DocbookTool.

For example:

```markdown
![some diagram](diagram.puml)
```

will become inlined:

````markdown
```puml
@startuml
...
@enduml
```
````

which is subsequently picked up by the `\Roave\DocbookTool\Formatter\RenderPlantUmlDiagramInline` formatter to convert it into a PNG diagram.