### PR TITLE
Switch to PHPUnit 10 attributes instead of PHPDoc

### DIFF
--- a/test/integration/Writer/MultiplePdfFilesWriterTest.php
+++ b/test/integration/Writer/MultiplePdfFilesWriterTest.php
@@ -4,6 +4,7 @@ declare(strict_types=1);
 
 namespace Roave\DocbookToolIntegrationTest\Writer;
 
+use PHPUnit\Framework\Attributes\CoversClass;
 use PHPUnit\Framework\TestCase;
 use Psr\Log\NullLogger;
 use Roave\DocbookTool\DocbookPage;
@@ -13,7 +14,7 @@ use Twig\Environment as Twig;
 use function file_exists;
 use function unlink;
 
-/** @covers \Roave\DocbookTool\Writer\MultiplePdfFilesWriter */
+#[CoversClass(MultiplePdfFilesWriter::class)]
 final class MultiplePdfFilesWriterTest extends TestCase
 {
     private const OUTPUT_PDF_PATH = __DIR__;

--- a/test/unit/DocbookPageTest.php
+++ b/test/unit/DocbookPageTest.php
@@ -4,11 +4,12 @@ declare(strict_types=1);
 
 namespace Roave\DocbookToolUnitTest;
 
+use PHPUnit\Framework\Attributes\CoversClass;
 use PHPUnit\Framework\TestCase;
 use Roave\DocbookTool\DocbookPage;
 use RuntimeException;
 
-/** @covers \Roave\DocbookTool\DocbookPage */
+#[CoversClass(DocbookPage::class)]
 final class DocbookPageTest extends TestCase
 {
     public function testEmptyPageThrowsExceptionWhenFetchingTitle(): void

--- a/test/unit/Formatter/ExtractFrontMatterTest.php
+++ b/test/unit/Formatter/ExtractFrontMatterTest.php
@@ -4,6 +4,8 @@ declare(strict_types=1);
 
 namespace Roave\DocbookToolUnitTest\Formatter;
 
+use PHPUnit\Framework\Attributes\CoversClass;
+use PHPUnit\Framework\Attributes\DataProvider;
 use PHPUnit\Framework\TestCase;
 use Psr\Log\NullLogger;
 use Roave\DocbookTool\DocbookPage;
@@ -11,7 +13,7 @@ use Roave\DocbookTool\Formatter\AggregatePageFormatter;
 use Roave\DocbookTool\Formatter\ExtractFrontMatter;
 use Roave\DocbookTool\Formatter\MarkdownToHtml;
 
-/** @covers \Roave\DocbookTool\Formatter\ExtractFrontMatter */
+#[CoversClass(ExtractFrontMatter::class)]
 final class ExtractFrontMatterTest extends TestCase
 {
     /** @return array<string,array{content:non-empty-string,expectedTitle:non-empty-string}> */
@@ -75,9 +77,8 @@ MD,
     /**
      * @param non-empty-string $content
      * @param non-empty-string $expectedTitle
-     *
-     * @dataProvider titleProvider
      */
+    #[DataProvider('titleProvider')]
     public function testTitleCanBeSetInFrontMatter(string $content, string $expectedTitle): void
     {
         $logger = new NullLogger();

--- a/test/unit/Formatter/InlineCodeFromFileTest.php
+++ b/test/unit/Formatter/InlineCodeFromFileTest.php
@@ -4,12 +4,13 @@ declare(strict_types=1);
 
 namespace Roave\DocbookToolUnitTest\Formatter;
 
+use PHPUnit\Framework\Attributes\CoversClass;
 use PHPUnit\Framework\TestCase;
 use Psr\Log\NullLogger;
 use Roave\DocbookTool\DocbookPage;
 use Roave\DocbookTool\Formatter\InlineCodeFromFile;
 
-/** @covers \Roave\DocbookTool\Formatter\InlineCodeFromFile */
+#[CoversClass(InlineCodeFromFile::class)]
 final class InlineCodeFromFileTest extends TestCase
 {
     public function testExternalSourceCodeIsInlined(): void

--- a/test/unit/Formatter/InlineExternalImagesTest.php
+++ b/test/unit/Formatter/InlineExternalImagesTest.php
@@ -4,6 +4,8 @@ declare(strict_types=1);
 
 namespace Roave\DocbookToolUnitTest\Formatter;
 
+use PHPUnit\Framework\Attributes\CoversClass;
+use PHPUnit\Framework\Attributes\DataProvider;
 use PHPUnit\Framework\TestCase;
 use Psr\Log\NullLogger;
 use Roave\DocbookTool\DocbookPage;
@@ -13,7 +15,7 @@ use Safe\Exceptions\FilesystemException;
 
 use function sprintf;
 
-/** @covers \Roave\DocbookTool\Formatter\InlineExternalImages */
+#[CoversClass(InlineExternalImages::class)]
 final class InlineExternalImagesTest extends TestCase
 {
     private const MIME_JPG = 'image/jpeg';
@@ -61,9 +63,8 @@ final class InlineExternalImagesTest extends TestCase
      * @param non-empty-string $contentPath
      * @param non-empty-string $imagePath
      * @param non-empty-string $expectedMimeType
-     *
-     * @dataProvider contentAndImagePathProvider
      */
+    #[DataProvider('contentAndImagePathProvider')]
     public function testExternalImagesAreInlined(string $contentPath, string $imagePath, string $expectedMimeType): void
     {
         $markdown = <<<MD

--- a/test/unit/Writer/ConfluenceWriterTest.php
+++ b/test/unit/Writer/ConfluenceWriterTest.php
@@ -10,6 +10,7 @@ use GuzzleHttp\HandlerStack;
 use GuzzleHttp\Middleware;
 use GuzzleHttp\Psr7\MultipartStream;
 use GuzzleHttp\Psr7\Response;
+use PHPUnit\Framework\Attributes\CoversClass;
 use PHPUnit\Framework\TestCase;
 use Psr\Http\Message\RequestInterface;
 use Psr\Log\LoggerInterface;
@@ -26,7 +27,7 @@ use function str_replace;
 
 use const JSON_THROW_ON_ERROR;
 
-/** @covers \Roave\DocbookTool\Writer\ConfluenceWriter */
+#[CoversClass(ConfluenceWriter::class)]
 final class ConfluenceWriterTest extends TestCase
 {
     // Indices for Guzzle transactions, as MockHandler only likes integer keys


### PR DESCRIPTION
Small thing. Not sure in which direction you want to go, but since PHPDoc is deprecated with PHPUnit 11 and I'm adding attribute usage in my other PR, I thought it might be a good idea to keep this stuff consistent.