### PR TITLE
Fix the Docker multi-arch builds

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -8,26 +8,39 @@ jobs:
     name: Build CI container
     runs-on: ubuntu-latest
     steps:
-      - name: "Install BuildX"
+      - name: Set up QEMU
+        uses: docker/setup-qemu-action@v3
+
+      - name: Setup Docker buildx
         uses: docker/setup-buildx-action@v3
         with:
           install: true
 
-      - name: "Build docker image"
-        uses: "docker/build-push-action@v6"
+      # @todo move after the build
+      - name: Build docker image (multi-arch validation)
+        uses: docker/build-push-action@v6
         with:
-          target: "development"
-          tags: "ghcr.io/roave/docbooktool:test-image"
-          push: "false"
-          load: "true"
-          cache-from: "type=gha,scope=ci-cache"
-          cache-to: "type=gha,mode=max,scope=ci-cache"
+          target: production
+          tags: ghcr.io/roave/docbooktool:test-image
+          platforms: linux/amd64,linux/arm64
+          cache-from: type=gha,scope=ci-cache
+          cache-to: type=gha,mode=max,scope=ci-cache
 
-      - name: "Psalm"
-        run: "docker run --rm --entrypoint=php ghcr.io/roave/docbooktool:test-image vendor/bin/psalm"
+      - name: Build docker image
+        uses: docker/build-push-action@v6
+        with:
+          target: development
+          tags: ghcr.io/roave/docbooktool:test-image
+          push: false
+          load: true
+          cache-from: type=gha,scope=ci-cache
+          cache-to: type=gha,mode=max,scope=ci-cache
 
-      - name: "PHPUnit"
-        run: "docker run --rm --entrypoint=php ghcr.io/roave/docbooktool:test-image vendor/bin/phpunit"
+      - name: Psalm
+        run: docker run --rm --entrypoint=php ghcr.io/roave/docbooktool:test-image vendor/bin/psalm
+
+      - name: PHPUnit
+        run: docker run --rm --entrypoint=php ghcr.io/roave/docbooktool:test-image vendor/bin/phpunit
 
       - name: "PHPCS"
-        run: "docker run --rm --entrypoint=php ghcr.io/roave/docbooktool:test-image vendor/bin/phpcs"
+        run: docker run --rm --entrypoint=php ghcr.io/roave/docbooktool:test-image vendor/bin/phpcs

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -16,16 +16,6 @@ jobs:
         with:
           install: true
 
-      # @todo move after the build
-      - name: Build docker image (multi-arch validation)
-        uses: docker/build-push-action@v6
-        with:
-          target: production
-          tags: ghcr.io/roave/docbooktool:test-image
-          platforms: linux/amd64,linux/arm64
-          cache-from: type=gha,scope=ci-cache
-          cache-to: type=gha,mode=max,scope=ci-cache
-
       - name: Build docker image
         uses: docker/build-push-action@v6
         with:
@@ -44,3 +34,12 @@ jobs:
 
       - name: "PHPCS"
         run: docker run --rm --entrypoint=php ghcr.io/roave/docbooktool:test-image vendor/bin/phpcs
+
+      - name: Build docker image (multi-arch validation)
+        uses: docker/build-push-action@v6
+        with:
+          target: production
+          tags: ghcr.io/roave/docbooktool:test-image
+          platforms: linux/amd64,linux/arm64
+          cache-from: type=gha,scope=ci-cache
+          cache-to: type=gha,mode=max,scope=ci-cache

--- a/Dockerfile
+++ b/Dockerfile
@@ -2,7 +2,7 @@
 
 FROM composer:2.8.5 AS composer-base-image
 FROM node:23.4.0 AS npm-base-image
-FROM ubuntu:24.04 AS ubuntu-base-image
+FROM ubuntu:22.04 AS ubuntu-base-image
 
 FROM npm-base-image AS npm-dependencies
 

--- a/Makefile
+++ b/Makefile
@@ -1,4 +1,4 @@
-.PHONY: *
+.PHONY: help build build-tested test cs static-analysis test-output production validate-multiarch
 
 CLEAR_CONFIG_CACHE=rm -f storage/app/vars/*
 OPTS=
@@ -27,4 +27,13 @@ test-output: ## Write the test fixture outputs to build/ directory - useful for 
 	docker buildx build --output=build --target=test-output --tag=ghcr.io/roave/docbooktool:test-image .
 
 production: ## Build and tag a production image
-	docker buildx build --load --target=production  --tag=ghcr.io/roave/docbooktool:latest .
+	docker buildx build --load --target=production --tag=ghcr.io/roave/docbooktool:latest .
+
+.builder-name:
+	docker buildx create --use > .builder-name
+
+validate-multiarch: .builder-name ## Validate the production build, multi-arch
+	docker buildx ls
+	docker buildx build --platform linux/amd64,linux/arm64 --target production --tag ghcr.io/roave/docbooktool:test-image .
+	docker buildx rm `cat < .builder-name`
+	rm .builder-name


### PR DESCRIPTION
Revert back to Ubuntu 22.04 for base image
    
There seems to be some weird openssl/curl/ubuntu incompatibility, seemingly only on Ubuntu 24.04, and only when running on an amd64 system doing multi-arch builds for arm64+amd64... incidentally, exactly how we build...
    
Refs:
    
- https://www.mail-archive.com/search?l=ubuntu-bugs@lists.ubuntu.com&q=subject:%22%5C%5BBug+2073448%5C%5D+Re%5C%3A+OpenSSL+SSL_connect%5C%3A+SSL_ERROR_SYSCALL+in+connection%22&o=newest&f=1
- https://github.com/curl/curl/issues/14154
